### PR TITLE
CB-5416 - Adding support for auto-managing permissions

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -49,16 +49,6 @@ see the Privacy Guide.
 
     cordova plugin add org.apache.cordova.geolocation
 
-### Firefox OS Quirks
-
-Create __www/manifest.webapp__ as described in 
-[Manifest Docs](https://developer.mozilla.org/en-US/Apps/Developing/Manifest).
-Add permisions: 
-
-    "permissions": {
-		"geolocation": { "description": "Used to position the map to your current position" }
-	}
-
 ## Supported Platforms
 
 - Amazon Fire OS

--- a/plugin.xml
+++ b/plugin.xml
@@ -201,11 +201,9 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
     <!-- firefoxos -->
     <platform name="firefoxos">
-        <config-file target="config.xml" parent="/*">
-            <feature name="Geolocation">
-                <param name="firefoxos-package" value="Geolocation" />
-            </feature>
-        </config-file>
+      <config-file target="config.xml" parent="/*">
+          <permission name="geolocation" description="Required for accessing user location." />
+      </config-file>
 
         <js-module src="src/firefoxos/GeolocationProxy.js" name="GeolocationProxy">
             <runs />


### PR DESCRIPTION
With [CB-5416](https://github.com/apache/cordova-cli/pull/168) merged into cordova-cli, we can have plugins automatically set the permissions in the manifest. Reviewed by @zalun.
