### PR TITLE
[CB-6422] Use cordova/exec/proxy instead of platform dupes

### DIFF
--- a/src/firefoxos/GeolocationProxy.js
+++ b/src/firefoxos/GeolocationProxy.js
@@ -61,4 +61,4 @@ module.exports = {
     }
 };
 
-require("cordova/firefoxos/commandProxy").add("Geolocation", module.exports);
+require("cordova/exec/proxy").add("Geolocation", module.exports);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-6422
[CB-6422] Use cordova/exec/proxy instead of platform dupes
