### PR TITLE
fix(ios): Clearing all Watches stops Location Services (CB-7556)

### DIFF
--- a/src/ios/CDVLocation.m
+++ b/src/ios/CDVLocation.m
@@ -267,6 +267,9 @@
 
     if (self.locationData && self.locationData.watchCallbacks && [self.locationData.watchCallbacks objectForKey:timerId]) {
         [self.locationData.watchCallbacks removeObjectForKey:timerId];
+        if([self.locationData.watchCallbacks count] == 0) {
+            [self _stopLocation];
+        }
     }
 }
 


### PR DESCRIPTION
iOS shows a little arrow in the status bar if location services are in use. When you set a watch on Location Manager, it starts tracking position, and the arrow symbol appears. However, when that watch is cleared, no command to Location Manager is sent to stop tracking, so the arrow stays visible, even though in reality, the app is not using location services. My guess is that this also impacts battery life to some extent, especially if your iOS app has background location enabled.

This fix would automatically stop tracking location once all watched are cleared, so that the arrow symbol in the iOS status will disappear.

Tested on iOS 7.1.2.

(Note: I don't really want to go through the rigamarole of signing up to be a contributor, so if someone else wants to take credit for this, go ahead)
