### PR TITLE
[CB-5753] Do not stop updating location when the error is 'kCLErrorLocationUnknown'

### DIFF
--- a/src/ios/CDVLocation.m
+++ b/src/ios/CDVLocation.m
@@ -343,8 +343,10 @@
         [self returnLocationError:positionError withMessage:[error localizedDescription]];
     }
 
-    [self.locationManager stopUpdatingLocation];
-    __locationStarted = NO;
+    if (error.code != kCLErrorLocationUnknown) {
+      [self.locationManager stopUpdatingLocation];
+      __locationStarted = NO;
+    }
 }
 
 //iOS8+


### PR DESCRIPTION
After 8-12 minutes the location plugin stops updating in ios because of an error that usually can be ignored (kCLErrorLocationUnknown).
This is a fix for the following issue: https://issues.apache.org/jira/browse/CB-5753
