### PR TITLE
CB-8085 Fix geolocation plugin on Windows

### DIFF
--- a/src/windows/GeolocationProxy.js
+++ b/src/windows/GeolocationProxy.js
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2013 Research In Motion Limited.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,7 +111,7 @@ module.exports = {
             highAccuracy = args[1],
 
             onPositionChanged = function (e) {
-                success(createResult(e.position));
+                success(createResult(e.position), {keepCallback: true});
             },
 
             onStatusChanged = function (e) {
@@ -141,6 +141,14 @@ module.exports = {
         loc.desiredAccuracy = highAccuracy ?
                 Windows.Devices.Geolocation.PositionAccuracy.high :
                 Windows.Devices.Geolocation.PositionAccuracy.default;
+
+        if (cordova.platformId == 'windows' && WinJS.Utilities.isPhone) {
+            // on Windows Phone 8.1 'positionchanged' event fails with error below if movementThreshold is not set
+            // JavaScript runtime error: Operation aborted
+            // You must set the MovementThreshold property or the ReportInterval property before adding event handlers.
+            // WinRT information: You must set the MovementThreshold property or the ReportInterval property before adding event handlers
+            loc.movementThreshold = loc.movementThreshold || 1; // 1 meter
+        }
 
         loc.addEventListener("positionchanged", onPositionChanged);
         loc.addEventListener("statuschanged", onStatusChanged);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-8085

This patch adds keepCallback property to tell proxy preserve callback so that it could be invoked next time.

When running on Windows Phone 8.1: added dummy 1 meter value for geolocator.movementThreshold to prevent the following error (no such problem  when running on Windows 8/8.1)

```
// JavaScript runtime error: Operation aborted
// You must set the MovementThreshold property or the ReportInterval property before adding event handlers.

```

http://blogs.windows.com/buildingapps/2012/12/03/geoposition-advanced-tracking-scenarios-for-windows-phone-8/
