### PR TITLE
fix(ios): Fixed returnLocationError function's issues

### DIFF
--- a/src/ios/CDVLocation.m
+++ b/src/ios/CDVLocation.m
@@ -315,13 +315,23 @@
     [posError setObject:message ? message:@"" forKey:@"message"];
     CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:posError];
 
-    for (NSString* callbackId in self.locationData.locationCallbacks) {
-        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    for (id callbackId in self.locationData.locationCallbacks) {
+        if([callbackId isKindOfClass:[NSNumber class]]) {
+            [self.commandDelegate sendPluginResult:result callbackId:[callbackId stringValue]];
+        }
+        else {
+            [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+        }
         [self.locationData.locationCallbacks removeObject:callbackId];
     }
 
-    for (NSString* callbackId in self.locationData.watchCallbacks) {
-        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+    for (id callbackId in self.locationData.watchCallbacks) {
+        if([callbackId isKindOfClass:[NSNumber class]]) {
+            [self.commandDelegate sendPluginResult:result callbackId:[callbackId stringValue]];
+        }
+        else {
+            [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+        }
         [self.locationData.watchCallbacks removeObjectForKey:callbackId];
     }
 }

--- a/src/ios/CDVLocation.m
+++ b/src/ios/CDVLocation.m
@@ -317,12 +317,12 @@
 
     for (NSString* callbackId in self.locationData.locationCallbacks) {
         [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+        [self.locationData.locationCallbacks removeObject:callbackId];
     }
-
-    [self.locationData.locationCallbacks removeAllObjects];
 
     for (NSString* callbackId in self.locationData.watchCallbacks) {
         [self.commandDelegate sendPluginResult:result callbackId:callbackId];
+        [self.locationData.watchCallbacks removeObjectForKey:callbackId];
     }
 }
 


### PR DESCRIPTION
There were 2 issues with returnLocationError function.
The function doesn't parse the NSNumber callback id to NSString.
That issue results the JS error callback function not getting called.

Also, the watchCallbackIds are not removed after error callback.
So, on next returnLocationError call, it results errors.
