### PR TITLE
Allow Android devices without GPS to still install

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -35,8 +35,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <platform name="android">
 
         <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-            <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+            <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:required="false" />
+            <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:required="false" />
         </config-file>
 
     </platform>
@@ -45,8 +45,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <platform name="amazon-fireos">
 
         <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-            <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+            <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:required="false" />
+            <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:required="false" />
         </config-file>
         
     </platform>


### PR DESCRIPTION
Apps with this plugin being used will not be install the Android app from the Google Play store due to permission restrictions. Setting android:required to false will still add this permission to the project but not preclude the app from being installed on a device without GPS.