### PR TITLE
CB-8826 [iOS 8+] Request WhenInUse permission before Always permission

### DIFF
--- a/src/ios/CDVLocation.m
+++ b/src/ios/CDVLocation.m
@@ -122,17 +122,17 @@
     NSUInteger code = [CLLocationManager authorizationStatus];
     if (code == kCLAuthorizationStatusNotDetermined && ([self.locationManager respondsToSelector:@selector(requestAlwaysAuthorization)] || [self.locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)])) { //iOS8+
         __highAccuracyEnabled = enableHighAccuracy;
-        if([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"]){
-            [self.locationManager requestAlwaysAuthorization];
-        } else if([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"]) {
-            [self.locationManager  requestWhenInUseAuthorization];
+        if([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"]){
+            [self.locationManager requestWhenInUseAuthorization];
+        } else if([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"]) {
+            [self.locationManager  requestAlwaysAuthorization];
         } else {
             NSLog(@"[Warning] No NSLocationAlwaysUsageDescription or NSLocationWhenInUseUsageDescription key is defined in the Info.plist file.");
         }
         return;
     }
 #endif
-    
+
     // Tell the location manager to start notifying us of location updates. We
     // first stop, and then start the updating to ensure we get at least one
     // update, even if our location did not change.


### PR DESCRIPTION
First reported here: https://issues.apache.org/jira/browse/CB-8826

Currently the plugin asks for background location first if `NSLocationAlwaysUsageDescription` is in place along with `NSLocationWhenInUseUsageDescription`. Given the current plugin functionality, this is unnecessary and privacy wise disturbing to user.

Apple documentation:
> Requesting “Always” authorization is discouraged because of the potential negative impacts to user privacy. You should request this level of authorization only when doing so offers a genuine benefit to the user.

This commit allows other plugins to request background permission separately.