### PR TITLE
refactor(ios): Prevent API Deprecation Warnings thru pre-processor macros

### DIFF
--- a/src/ios/CDVLocation.m
+++ b/src/ios/CDVLocation.m
@@ -82,14 +82,21 @@
 
 - (BOOL)isLocationServicesEnabled
 {
-    BOOL locationServicesEnabledInstancePropertyAvailable = [self.locationManager respondsToSelector:@selector(locationServicesEnabled)]; // iOS 3.x
-    BOOL locationServicesEnabledClassPropertyAvailable = [CLLocationManager respondsToSelector:@selector(locationServicesEnabled)]; // iOS 4.x
 
+#ifdef __IPHONE_4_0
+    BOOL locationServicesEnabledClassPropertyAvailable = [CLLocationManager respondsToSelector:@selector(locationServicesEnabled)]; // iOS 4.x
     if (locationServicesEnabledClassPropertyAvailable) { // iOS 4.x
         return [CLLocationManager locationServicesEnabled];
-    } else if (locationServicesEnabledInstancePropertyAvailable) { // iOS 2.x, iOS 3.x
+    }
+#endif
+#ifndef __IPHONE_4_0
+    BOOL locationServicesEnabledInstancePropertyAvailable = [self.locationManager respondsToSelector:@selector(locationServicesEnabled)]; // iOS 3.x
+
+    if (locationServicesEnabledInstancePropertyAvailable) { // iOS 2.x, iOS 3.x
         return [(id)self.locationManager locationServicesEnabled];
-    } else {
+    }
+#endif
+    else {
         return NO;
     }
 }


### PR DESCRIPTION
I've wrapped the call to `locationServicesEnabled` which is causing a Deprecation warning under compilation, in a `#ifndev __IPHONE_4_0` preprocessor macro. 

The better solution would be to drop any code that accommodates devices that old, but I'll start here.
