### PR TITLE
fix(android): Fix crash on deny permission request on Android M

### DIFF
--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -68,8 +68,11 @@ public class Geolocation extends CordovaPlugin {
             if(r == PackageManager.PERMISSION_DENIED)
             {
                 LOG.d(TAG, "Permission Denied!");
-                result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION);
-                context.sendPluginResult(result);
+				if (context != null)
+				{
+					result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION);
+					context.sendPluginResult(result);
+				}
                 return;
             }
         }


### PR DESCRIPTION
On Android 6.0 when asking for permission to access location, answering Deny will cause application crash
