### PR TITLE
CB-8443 Android: nothing happens if GPS is turned off

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ error, the `geolocationError` callback is passed a
 
     navigator.geolocation.getCurrentPosition(onSuccess, onError);
 
+### Android Quirks
+
+If Geolocation service is turned off the `onError` callback is invoked after `timeout` interval (if specified).
+If `timeout` parameter is not specified then no callback is called.
+
 ## navigator.geolocation.watchPosition
 
 Returns the device's current position when a change in position is detected.
@@ -206,7 +211,8 @@ Optional parameters to customize the retrieval of the geolocation
 
 ### Android Quirks
 
-Android 2.x emulators do not return a geolocation result unless the `enableHighAccuracy` option is set to `true`.
+If Geolocation service is turned off the `onError` callback is invoked after `timeout` interval (if specified).
+If `timeout` parameter is not specified then no callback is called.
 
 ## navigator.geolocation.clearWatch
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-8443

* Documented native Android behavior when location service is turned off and no timeout parameter is specified
* Removed old Android quirks for Android 2.x (not supported anymore)