### PR TITLE
Update iOS geolocation plugin to avoid THREAD WARNING: ['Geolocation'…

### DIFF
--- a/src/ios/CDVLocation.m
+++ b/src/ios/CDVLocation.m
@@ -192,35 +192,37 @@
 
 - (void)getLocation:(CDVInvokedUrlCommand*)command
 {
-    NSString* callbackId = command.callbackId;
-    BOOL enableHighAccuracy = [[command argumentAtIndex:0] boolValue];
+    [self.commandDelegate runInBackground:^{
+        NSString* callbackId = command.callbackId;
+        BOOL enableHighAccuracy = [[command argumentAtIndex:0] boolValue];
 
-    if ([self isLocationServicesEnabled] == NO) {
-        NSMutableDictionary* posError = [NSMutableDictionary dictionaryWithCapacity:2];
-        [posError setObject:[NSNumber numberWithInt:PERMISSIONDENIED] forKey:@"code"];
-        [posError setObject:@"Location services are disabled." forKey:@"message"];
-        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:posError];
-        [self.commandDelegate sendPluginResult:result callbackId:callbackId];
-    } else {
-        if (!self.locationData) {
-            self.locationData = [[CDVLocationData alloc] init];
-        }
-        CDVLocationData* lData = self.locationData;
-        if (!lData.locationCallbacks) {
-            lData.locationCallbacks = [NSMutableArray arrayWithCapacity:1];
-        }
-
-        if (!__locationStarted || (__highAccuracyEnabled != enableHighAccuracy)) {
-            // add the callbackId into the array so we can call back when get data
-            if (callbackId != nil) {
-                [lData.locationCallbacks addObject:callbackId];
-            }
-            // Tell the location manager to start notifying us of heading updates
-            [self startLocation:enableHighAccuracy];
+        if ([self isLocationServicesEnabled] == NO) {
+            NSMutableDictionary* posError = [NSMutableDictionary dictionaryWithCapacity:2];
+            [posError setObject:[NSNumber numberWithInt:PERMISSIONDENIED] forKey:@"code"];
+            [posError setObject:@"Location services are disabled." forKey:@"message"];
+            CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:posError];
+            [self.commandDelegate sendPluginResult:result callbackId:callbackId];
         } else {
-            [self returnLocationInfo:callbackId andKeepCallback:NO];
+            if (!self.locationData) {
+                self.locationData = [[CDVLocationData alloc] init];
+            }
+            CDVLocationData* lData = self.locationData;
+            if (!lData.locationCallbacks) {
+                lData.locationCallbacks = [NSMutableArray arrayWithCapacity:1];
+            }
+
+            if (!__locationStarted || (__highAccuracyEnabled != enableHighAccuracy)) {
+                // add the callbackId into the array so we can call back when get data
+                if (callbackId != nil) {
+                    [lData.locationCallbacks addObject:callbackId];
+                }
+                // Tell the location manager to start notifying us of heading updates
+                [self startLocation:enableHighAccuracy];
+            } else {
+                [self returnLocationInfo:callbackId andKeepCallback:NO];
+            }
         }
-    }
+    }];
 }
 
 - (void)addWatch:(CDVInvokedUrlCommand*)command


### PR DESCRIPTION
To avoid warning  "THREAD WARNING: ['Geolocation'] took 'X' ms. Plugin should use a background thread.", i added     [self.commandDelegate runInBackground:^{ }]; around the code in getLocation method. By doing so, the execution of this code takes place in a new thread and works all the same. 

Apple sometimes can reject application because of that, so it can only be good to add it, as simple as it is.