### PR TITLE
CB-10574: MobileSpec can't get results for WP8.1 Builds

### DIFF
--- a/src/windows/GeolocationProxy.js
+++ b/src/windows/GeolocationProxy.js
@@ -14,47 +14,43 @@
  * limitations under the License.
  */
 
-var PositionError = require('./PositionError'),
-    ids = {},
-    loc;
+var PositionError   = require('./PositionError');
+var callbacks       = {};
+var locs            = {};
 
-function ensureLocator() {
+function ensureAndCreateLocator() {
     var deferral;
 
-    if (!loc) {
-        loc = new Windows.Devices.Geolocation.Geolocator();
+    loc = new Windows.Devices.Geolocation.Geolocator();
 
-        if (typeof Windows.Devices.Geolocation.Geolocator.requestAccessAsync === 'function') {
-            deferral = Windows.Devices.Geolocation.Geolocator.requestAccessAsync().then(function (result) {
-                if (result === Windows.Devices.Geolocation.GeolocationAccessStatus.allowed) {
-                    return loc;
-                }
+    if (typeof Windows.Devices.Geolocation.Geolocator.requestAccessAsync === 'function') {
+        deferral = Windows.Devices.Geolocation.Geolocator.requestAccessAsync().then(function (result) {
+            if (result === Windows.Devices.Geolocation.GeolocationAccessStatus.allowed) {
+                return loc;
+            }
 
-                return WinJS.Promise.wrapError({
-                    code: PositionError.PERMISSION_DENIED,
-                    message: 'Geolocation access has not been allowed by user.'
-                });
+            return WinJS.Promise.wrapError({
+                code: PositionError.PERMISSION_DENIED,
+                message: 'Geolocation access has not been allowed by user.'
             });
-        } else {
-            deferral = WinJS.Promise.wrap(loc);
-        }
+        });
     } else {
         deferral = WinJS.Promise.wrap(loc);
-    }    
+    }
 
     return deferral;
 }
 
-function createErrorCode() {
+function createErrorCode(loc) {
     switch (loc.locationStatus) {
         case Windows.Devices.Geolocation.PositionStatus.initializing:
             // This status indicates that a location device is still initializing
         case Windows.Devices.Geolocation.PositionStatus.noData:
-            // No location data is currently available 
+            // No location data is currently available
         case Windows.Devices.Geolocation.PositionStatus.notInitialized:
             // This status indicates that the app has not yet requested
-            // location data by calling GetGeolocationAsync() or 
-            // registering an event handler for the positionChanged event. 
+            // location data by calling GetGeolocationAsync() or
+            // registering an event handler for the positionChanged event.
         case Windows.Devices.Geolocation.PositionStatus.notAvailable:
             // Location is not available on this version of Windows
             return PositionError.POSITION_UNAVAILABLE;
@@ -76,7 +72,7 @@ function createResult(pos) {
         altitudeAccuracy: pos.coordinate.altitudeAccuracy,
         timestamp: pos.coordinate.timestamp
     };
-    
+
     if (pos.coordinate.point) {
         res.latitude = pos.coordinate.point.position.latitude;
         res.longitude = pos.coordinate.point.position.longitude;
@@ -86,13 +82,13 @@ function createResult(pos) {
         res.longitude = pos.coordinate.longitude;
         res.altitude = pos.coordinate.altitude;
     }
-    
+
     return res;
 }
 
 module.exports = {
     getLocation: function (success, fail, args, env) {
-        ensureLocator().done(function () {
+        ensureAndCreateLocator().done(function (loc) {
             if (loc) {
                 var highAccuracy = args[0],
                     maxAge = args[1];
@@ -109,7 +105,7 @@ module.exports = {
                     },
                     function (err) {
                         fail({
-                            code: createErrorCode(),
+                            code: createErrorCode(loc),
                             message: err.message
                         });
                     }
@@ -125,9 +121,9 @@ module.exports = {
     },
 
     addWatch: function (success, fail, args, env) {
-        ensureLocator().done(function () {
-            var clientId = args[0],
-            highAccuracy = args[1],
+        ensureAndCreateLocator().done(function (loc) {
+            var clientId = args[0];
+            var highAccuracy = args[1];
 
             onPositionChanged = function (e) {
                 success(createResult(e.position), { keepCallback: true });
@@ -172,19 +168,22 @@ module.exports = {
             loc.addEventListener("positionchanged", onPositionChanged);
             loc.addEventListener("statuschanged", onStatusChanged);
 
-            ids[clientId] = { pos: onPositionChanged, status: onStatusChanged };
-        }, fail);        
+            callbacks[clientId] = { pos: onPositionChanged, status: onStatusChanged };
+            locs[clientId] = loc;
+        }, fail);
     },
 
     clearWatch: function (success, fail, args, env) {
-        var clientId = args[0],
-            callbacks = ids[clientId];
+        var clientId = args[0];
+        var callback = callbacks[clientId];
+        var loc      = locs[clientId]
 
-        if (callbacks) {
-            loc.removeEventListener("positionchanged", callbacks.pos);
-            loc.removeEventListener("statuschanged", callbacks.status);
+        if (callback && loc) {
+            loc.removeEventListener("positionchanged", callback.pos);
+            loc.removeEventListener("statuschanged", callback.status);
 
-            delete ids[clientId];
+            delete callbacks[clientId];
+            delete locs[clientId];
         }
 
         success();


### PR DESCRIPTION
The MobileSpec can't get results for WP8.1 Builds. 

**Why?**
Because, one of the tests in the geolocation plugin is failing and causes the app to crash. This test gets the "0x80004004 - JavaScript runtime error: Operation aborted" error. So, the app crashes. The issue around this test must be fixed for the CI to finish successfully for Windows Phone 8.1. 

**What is the scenario for the crash?**
The scenario could be seen manually also. When you run the mobilespec test for geolocatio API, try the following steps:

1. Start Watching 
2. Stop Watching
3. Start Watching
4. Start Watching 

The app will crash in step 4. But it will not crash on step 3.  

**Why does the app crash on step 4?**

Per code, the loc object (instance of Windows.Devices.Geolocation.Geolocator object) is being reused in both the steps - which causes the crash. 

**What is the fix?**

The current fix is to create  a new instance of the object instead of resuing the same object. I have validated the fix by running the geolocation tests and all of them are passing. 

**Related JIRA**

https://issues.apache.org/jira/browse/CB-10594

@riknoll @dblotsky @rakatyal @daserge @nikhilkh Can you please review and merge this PR?