### PR TITLE
CB-10574: MobileSpec can't get results for WP8.1 Builds

### DIFF
--- a/src/windows/GeolocationProxy.js
+++ b/src/windows/GeolocationProxy.js
@@ -24,7 +24,7 @@ var FALLBACK_EPSILON = 0.001;
 function ensureAndCreateLocator() {
     var deferral;
 
-    loc = new Windows.Devices.Geolocation.Geolocator();
+    var loc = new Windows.Devices.Geolocation.Geolocator();
 
     if (typeof Windows.Devices.Geolocation.Geolocator.requestAccessAsync === 'function') {
         deferral = Windows.Devices.Geolocation.Geolocator.requestAccessAsync().then(function (result) {


### PR DESCRIPTION
Adding 'var' to make the variable local.

@dblotsky @rakatyal Can you review and merge this PR?