### PR TITLE
[CB-11462] Fixes the Coordinate speed and heading attribute to follow the w3c specification on all platforms

### DIFF
--- a/www/Coordinates.js
+++ b/www/Coordinates.js
@@ -50,7 +50,7 @@ var Coordinates = function(lat, lng, alt, acc, head, vel, altacc) {
     /**
      * The direction the device is moving at the position.
      */
-    this.heading = (head !== undefined ? head : null);
+    this.heading = (typeof head === 'number' && head >= 0 && head <= 360 ? head : null);
     /**
      * The velocity with which the device is moving at the position.
      */

--- a/www/Coordinates.js
+++ b/www/Coordinates.js
@@ -54,7 +54,7 @@ var Coordinates = function(lat, lng, alt, acc, head, vel, altacc) {
     /**
      * The velocity with which the device is moving at the position.
      */
-    this.speed = (vel !== undefined ? vel : null);
+    this.speed = (typeof vel === 'number' && vel >= 0 ? vel : null);
 
     if (this.speed === 0 || this.speed === null) {
         this.heading = NaN;


### PR DESCRIPTION
iOS returns negative values for heading/course and speed when the values can not be determined. These values are exposed by the current API which leads to unwanted behavior of the API. This pull request adds extra checks to the `Coordinates` object and makes sure `speed` and `heading` can only have values defined in the [W3C Geolocation API Specification](https://dev.w3.org/geo/api/spec-source.html).

See also:
- https://dev.w3.org/geo/api/spec-source.html#heading
- https://dev.w3.org/geo/api/spec-source.html#speed
- https://developer.apple.com/library/ios/documentation/CoreLocation/Reference/CLLocation_Class/#//apple_ref/occ/instp/CLLocation/course
- https://developer.apple.com/library/ios/documentation/CoreLocation/Reference/CLLocation_Class/#//apple_ref/occ/instp/CLLocation/speed
### Platforms affected

Primary iOS. Fixes all invalid values provided by other platforms.
### What does this PR do?

Makes sure the resulting Coordinates object follows the W3C specification.
### What testing has been done on this change?

Tested on iOS.
### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
