### PR TITLE
CB-11962: (ios) Added variable NSLocationWhenInUseUsageDescription to Config.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,17 @@ error, the `geolocationError` callback is passed a
 
 ```
 
+### iOS Quirks
+ 
+ Since iOS 10 it's mandatory to add a `NSLocationWhenInUseUsageDescription` entry in the info.plist.
+ 
+ `NSLocationWhenInUseUsageDescription` describes the reason that the app accesses the user’s location. When the system prompts the user to allow access, this string is displayed as part of the dialog box. To add this entry you can pass the variable `GEOLOCATION_USAGE_DESCRIPTION` on plugin install.
+ 
+ Example:
+ `cordova plugin add cordova-plugin-geolocation --variable GEOLOCATION_USAGE_DESCRIPTION="your usage message"`
+ 
+ If you don't pass the variable, the plugin will add an empty string as value.
+ 
 ### Android Quirks
 
 If Geolocation service is turned off the `onError` callback is invoked after `timeout` interval (if specified).

--- a/plugin.xml
+++ b/plugin.xml
@@ -98,9 +98,10 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <header-file src="src/ios/CDVLocation.h" />
         <source-file src="src/ios/CDVLocation.m" />
         <framework src="CoreLocation.framework" />
-
+        
+        <preference name="GEOLOCATION_USAGE_DESCRIPTION" default=" " />
         <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
-            <string></string>
+            <string>$GEOLOCATION_USAGE_DESCRIPTION</string>
         </config-file>
 
     </platform>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Modifies plugin.xml to provide the value for NSLocationWhenInUseUsageDescription using a variable which can then be set in the plugin entry in the config.xml file rather than having to physically edit the plugin.xml file. cordova-plugin-contacts and cordova-plugin-camera follow the same strategy.

### What testing has been done on this change?

```
cordova create hello com.example.hello HelloWorld
$ cd hello
$ cordova platform add ios –save
$ cordova plugin add https://github.com/obione86/cordova-plugin-geolocation.git --variable GEOLOCATION_USAGE_DESCRIPTION="Thought it might be good to have a nosey" --save
```
Navigate to plugins\cordova-plugin-geolocation\plugin.xml and check the bottom of the ios section and it looks like this
```
<preference name="GEOLOCATION_USAGE_DESCRIPTION" default=" " />
<config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
      <string>$GEOLOCATION_USAGE_DESCRIPTION</string>
</config-file>
```
Open config.xml and the plugin section should have this 
```
<plugin name="cordova-plugin-geolocation" spec="https://github.com/obione86/cordova-plugin-geolocation.git">
        <variable name="GEOLOCATION_USAGE_DESCRIPTION" value="Thought it might be good to have a nosey" />
</plugin>
```
`$ cordova build ios`

Open platforms\ios\HelloWorld\HelloWorld-Info.plist and it should have
```
<key>NSLocationWhenInUseUsageDescription</key>
<string>Thought it might be good to have a nosey</string>
```

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

CB-11962: (ios) The NSLocationWhenInUseUsageDescription is required when using geolocation but at the moment is always set to an empty string. This commits adds a variable so that this value can be set in the config.xml file.