### PR TITLE
Update CDVLocation.m

### DIFF
--- a/src/ios/CDVLocation.m
+++ b/src/ios/CDVLocation.m
@@ -94,61 +94,62 @@
 
 - (void)startLocation:(BOOL)enableHighAccuracy
 {
-    if (![self isLocationServicesEnabled]) {
-        [self returnLocationError:PERMISSIONDENIED withMessage:@"Location services are not enabled."];
-        return;
-    }
-    if (![self isAuthorized]) {
-        NSString* message = nil;
-        BOOL authStatusAvailable = [CLLocationManager respondsToSelector:@selector(authorizationStatus)]; // iOS 4.2+
-        if (authStatusAvailable) {
-            NSUInteger code = [CLLocationManager authorizationStatus];
-            if (code == kCLAuthorizationStatusNotDetermined) {
-                // could return POSITION_UNAVAILABLE but need to coordinate with other platforms
-                message = @"User undecided on application's use of location services.";
-            } else if (code == kCLAuthorizationStatusRestricted) {
-                message = @"Application's use of location services is restricted.";
-            }
+    [self.commandDelegate runInBackground:^{
+        if (![self isLocationServicesEnabled]) {
+            [self returnLocationError:PERMISSIONDENIED withMessage:@"Location services are not enabled."];
+            return;
         }
-        // PERMISSIONDENIED is only PositionError that makes sense when authorization denied
-        [self returnLocationError:PERMISSIONDENIED withMessage:message];
-
-        return;
-    }
+        if (![self isAuthorized]) {
+            NSString* message = nil;
+            BOOL authStatusAvailable = [CLLocationManager respondsToSelector:@selector(authorizationStatus)]; // iOS 4.2+
+            if (authStatusAvailable) {
+                NSUInteger code = [CLLocationManager authorizationStatus];
+                if (code == kCLAuthorizationStatusNotDetermined) {
+                    // could return POSITION_UNAVAILABLE but need to coordinate with other platforms
+                    message = @"User undecided on application's use of location services.";
+                } else if (code == kCLAuthorizationStatusRestricted) {
+                    message = @"Application's use of location services is restricted.";
+                }
+            }
+            // PERMISSIONDENIED is only PositionError that makes sense when authorization denied
+            [self returnLocationError:PERMISSIONDENIED withMessage:message];
+            return;
+        }
 
 #ifdef __IPHONE_8_0
-    NSUInteger code = [CLLocationManager authorizationStatus];
-    if (code == kCLAuthorizationStatusNotDetermined && ([self.locationManager respondsToSelector:@selector(requestAlwaysAuthorization)] || [self.locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)])) { //iOS8+
-        __highAccuracyEnabled = enableHighAccuracy;
-        if([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"]){
-            [self.locationManager requestWhenInUseAuthorization];
-        } else if([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"]) {
-            [self.locationManager  requestAlwaysAuthorization];
-        } else {
-            NSLog(@"[Warning] No NSLocationAlwaysUsageDescription or NSLocationWhenInUseUsageDescription key is defined in the Info.plist file.");
+        NSUInteger code = [CLLocationManager authorizationStatus];
+        if (code == kCLAuthorizationStatusNotDetermined && ([self.locationManager respondsToSelector:@selector(requestAlwaysAuthorization)] || [self.locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)])) { //iOS8+
+            __highAccuracyEnabled = enableHighAccuracy;
+            if([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"]){
+                [self.locationManager requestWhenInUseAuthorization];
+            } else if([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"]) {
+                [self.locationManager  requestAlwaysAuthorization];
+            } else {
+                NSLog(@"[Warning] No NSLocationAlwaysUsageDescription or NSLocationWhenInUseUsageDescription key is defined in the Info.plist file.");
+            }
+            return;
         }
-        return;
-    }
 #endif
 
-    // Tell the location manager to start notifying us of location updates. We
-    // first stop, and then start the updating to ensure we get at least one
-    // update, even if our location did not change.
-    [self.locationManager stopUpdatingLocation];
-    [self.locationManager startUpdatingLocation];
-    __locationStarted = YES;
-    if (enableHighAccuracy) {
-        __highAccuracyEnabled = YES;
-        // Set distance filter to 5 for a high accuracy. Setting it to "kCLDistanceFilterNone" could provide a
-        // higher accuracy, but it's also just spamming the callback with useless reports which drain the battery.
-        self.locationManager.distanceFilter = 5;
-        // Set desired accuracy to Best.
-        self.locationManager.desiredAccuracy = kCLLocationAccuracyBest;
-    } else {
-        __highAccuracyEnabled = NO;
-        self.locationManager.distanceFilter = 10;
-        self.locationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers;
-    }
+        // Tell the location manager to start notifying us of location updates. We
+        // first stop, and then start the updating to ensure we get at least one
+        // update, even if our location did not change.
+        [self.locationManager stopUpdatingLocation];
+        [self.locationManager startUpdatingLocation];
+        __locationStarted = YES;
+        if (enableHighAccuracy) {
+            __highAccuracyEnabled = YES;
+            // Set distance filter to 5 for a high accuracy. Setting it to "kCLDistanceFilterNone" could provide a
+            // higher accuracy, but it's also just spamming the callback with useless reports which drain the battery.
+            self.locationManager.distanceFilter = 5;
+            // Set desired accuracy to Best.
+            self.locationManager.desiredAccuracy = kCLLocationAccuracyBest;
+        } else {
+            __highAccuracyEnabled = NO;
+            self.locationManager.distanceFilter = 10;
+            self.locationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers;
+        }
+    }];
 }
 
 - (void)_stopLocation


### PR DESCRIPTION
Just added background mode to this function:
- (void)startLocation:(BOOL)enableHighAccuracy
{
    [self.commandDelegate runInBackground:^{

This stops iOS from giving warnings that the Plugin should be executing in background mode, and also stops random crashes of the plugin and makes it more stable on iOS.

### Platforms affected
iOS

### What does this PR do?
Increase Stability by running Function in Background Mode.

### What testing has been done on this change?
iOS tests shows that without this PR, warning is showing and also plugin crashes at some points.
With the PR plugin gains stability, and no warning found.