### PR TITLE
CB-13267 (iOS): Remove ios usage descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,14 +161,19 @@ error, the `geolocationError` callback is passed a
 
 ### iOS Quirks
  
- Since iOS 10 it's mandatory to add a `NSLocationWhenInUseUsageDescription` entry in the info.plist.
- 
- `NSLocationWhenInUseUsageDescription` describes the reason that the app accesses the user's location. When the system prompts the user to allow access, this string is displayed as part of the dialog box. To add this entry you can pass the variable `GEOLOCATION_USAGE_DESCRIPTION` on plugin install.
- 
- Example:
- `cordova plugin add cordova-plugin-geolocation --variable GEOLOCATION_USAGE_DESCRIPTION="your usage message"`
- 
- If you don't pass the variable, the plugin will add an empty string as value.
+ Since iOS 10 it's mandatory to provide an usage description in the `info.plist` if trying to access privacy-sensitive data. When the system prompts the user to allow access, this usage description string will displayed as part of the permission dialog box, but if you didn't provide the usage description, the app will crash before showing the dialog. Also, Apple will reject apps that access private data but don't provide an usage description.
+
+ This plugins requires the following usage description:
+
+ * `NSLocationWhenInUseUsageDescription` describes the reason that the app accesses the user's location. 
+
+ To add this entry into the `info.plist`, you can use the `edit-config` tag in the `config.xml` like this:
+
+```
+<edit-config target="NSLocationWhenInUseUsageDescription" file="*-Info.plist" mode="merge">
+    <string>need location access to find things nearby</string>
+</edit-config>
+```
  
 ### Android Quirks
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -101,11 +101,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/ios/CDVLocation.m" />
         <framework src="CoreLocation.framework" />
 
-        <preference name="GEOLOCATION_USAGE_DESCRIPTION" default=" " />
-        <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
-            <string>$GEOLOCATION_USAGE_DESCRIPTION</string>
-        </config-file>
-
     </platform>
 
     <!-- blackberry10 -->

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -29,4 +29,7 @@
     <dependency id="cordova-plugin-device" url="https://github.com/apache/cordova-plugin-device" />
     <js-module src="tests.js" name="tests">
     </js-module>
+    <edit-config target="NSLocationWhenInUseUsageDescription" file="*-Info.plist" mode="merge">
+      <string>need location access to pass tests</string>
+    </edit-config>
 </plugin>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Remove variables for setting iOS usage descriptions as they cause conflict when other plugins try to access the same variables.

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
