### PR TITLE
CB-13294 Remove cordova-plugin-compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "engines": {
     "cordovaDependencies": {
       "3.0.0": {
-        "cordova": ">100"
+        "cordova": ">100",
+        "cordova-android": ">=6.3.0"
       }
     }
   },

--- a/plugin.xml
+++ b/plugin.xml
@@ -31,7 +31,9 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-geolocation.git</repo>
     <issue>https://issues.apache.org/jira/browse/CB/component/12320638</issue>
 
-    <dependency id="cordova-plugin-compat" version="^1.0.0" />
+    <engines>
+        <engine name="cordova-android" version=">=6.3.0" />
+    </engines>
 
     <!-- android -->
     <platform name="android">


### PR DESCRIPTION
### Platforms affected
cordova-android@6.3.0

### What does this PR do?
Removes the dependency on cordova-plugin-compat, and includes checks for min platform version.

### What testing has been done on this change?
Testing 1:
- Add local plugin to project containing cordova-android@6.3.0
- Verify plugin installs, and app runs.

Testing 2:
- Add local plugin to project containing cordova-android@6.2.3
- Verify plugin does not install.
- Console log as follows:

```
Plugin doesn't support this project's cordova-android version. cordova-android: 6.2.3, failed version requirement: >=6.3.0
Skipping 'cordova-plugin-geolocation' for android
```

This is desirable - this change stops the plugin being installed on `<cordova-android@6.3.0`

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
