### PR TITLE
CB-14085: Fix iOS usage description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,4 +67,4 @@ install:
 script:
 - npm test
 - node /tmp/paramedic/main.js --config pr/$PLATFORM --plugin $(pwd) --shouldUseSauce
-  --buildName travis-plugin-geolocation-$TRAVIS_JOB_NUMBER --force
+  --buildName travis-plugin-geolocation-$TRAVIS_JOB_NUMBER

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,4 +67,4 @@ install:
 script:
 - npm test
 - node /tmp/paramedic/main.js --config pr/$PLATFORM --plugin $(pwd) --shouldUseSauce
-  --buildName travis-plugin-geolocation-$TRAVIS_JOB_NUMBER
+  --buildName travis-plugin-geolocation-$TRAVIS_JOB_NUMBER --force

--- a/README.md
+++ b/README.md
@@ -156,19 +156,19 @@ error, the `geolocationError` callback is passed a
 
 ### iOS Quirks
  
- Since iOS 10 it's mandatory to provide an usage description in the `info.plist` if trying to access privacy-sensitive data. When the system prompts the user to allow access, this usage description string will displayed as part of the permission dialog box, but if you didn't provide the usage description, the app will crash before showing the dialog. Also, Apple will reject apps that access private data but don't provide an usage description.
+As precised on the (Apple documentation)[https://developer.apple.com/documentation/corelocation/choosing_the_authorization_level_for_location_services/requesting_always_authorization], this plugins requires the following usages descriptions to use native location services on iOS:
 
- This plugins requires the following usage description:
+* `NSLocationAlwaysAndWhenInUseUsageDescription`
+* `NSLocationWhenInUseUsageDescription`
 
- * `NSLocationWhenInUseUsageDescription` describes the reason that the app accesses the user's location. 
-
- To add this entry into the `info.plist`, you can use the `edit-config` tag in the `config.xml` like this:
+By default, the usage description value for both entries is set as: "The application needs to access location data to make the user experience more efficient and reliable."
+                                                                    
+If you want you can precise this value at installation by this way:
 
 ```
-<edit-config target="NSLocationWhenInUseUsageDescription" file="*-Info.plist" mode="merge">
-    <string>need location access to find things nearby</string>
-</edit-config>
+cordova plugin add cordova-plugin-geolocation --variable USAGE_DESCRIPTION="My usage description"
 ```
+
  
 ### Android Quirks
 

--- a/README.md
+++ b/README.md
@@ -156,14 +156,14 @@ error, the `geolocationError` callback is passed a
 
 ### iOS Quirks
  
-As precised on the (Apple documentation)[https://developer.apple.com/documentation/corelocation/choosing_the_authorization_level_for_location_services/requesting_always_authorization], this plugins requires the following usages descriptions to use native location services on iOS:
+As precised in the (Apple documentation)[https://developer.apple.com/documentation/corelocation/choosing_the_authorization_level_for_location_services/requesting_always_authorization], this plugin requires the following usage descriptions to use the native location service:
 
 * `NSLocationAlwaysAndWhenInUseUsageDescription`
 * `NSLocationWhenInUseUsageDescription`
 
 By default, the usage description value for both entries is set as: "The application needs to access location data to make the user experience more efficient and reliable."
                                                                     
-If you want you can precise this value at installation by this way:
+You can precise this value at installation:
 
 ```
 cordova plugin add cordova-plugin-geolocation --variable USAGE_DESCRIPTION="My usage description"

--- a/README.md
+++ b/README.md
@@ -156,12 +156,11 @@ error, the `geolocationError` callback is passed a
 
 ### iOS Quirks
  
-As precised in the (Apple documentation)[https://developer.apple.com/documentation/corelocation/choosing_the_authorization_level_for_location_services/requesting_always_authorization], this plugin requires the following usage descriptions to use the native location service:
+As precised in the (apple documentation)[https://developer.apple.com/documentation/corelocation/choosing_the_authorization_level_for_location_services/requesting_when_in_use_authorization], this plugin requires the following usage description to use the native location service:
 
-* `NSLocationAlwaysAndWhenInUseUsageDescription`
 * `NSLocationWhenInUseUsageDescription`
 
-By default, the usage description value for both entries is set as: "The application needs to access location data to make the user experience more efficient and reliable."
+By default, the usage description is set as: « The application needs to access location data to make the user experience more efficient and reliable. » 
                                                                     
 You can precise this value at installation:
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -67,8 +67,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <platform name="ios">
 
         <!-- Location Usage Description -->
-        <preference name="USAGE_DESCRIPTION" default="The application needs to access location data to make the user experience more efficient and reliable." mode="overwrite" />
-        <config-file parent="NSLocationAlwaysAndWhenInUseUsageDescription" target="*-Info.plist">
+        <preference name="USAGE_DESCRIPTION" default="The application needs to access location data to make the user experience more efficient and reliable." />
+        <config-file parent="NSLocationAlwaysAndWhenInUseUsageDescription" target="*-Info.plist" mode="overwrite">
             <string>$USAGE_DESCRIPTION</string>
         </config-file>
         <config-file parent="NSLocationWhenInUseUsageDescription" target="*-Info.plist" mode="overwrite">

--- a/plugin.xml
+++ b/plugin.xml
@@ -68,7 +68,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <!-- Location Usage Description -->
         <preference name="USAGE_DESCRIPTION" default="The application needs to access location data to make the user experience more efficient and reliable." />
-        <config-file parent="NSLocationWhenInUseUsageDescription" target="*-Info.plist" mode="overwrite">
+        <config-file parent="NSLocationWhenInUseUsageDescription" target="*-Info.plist">
             <string>$USAGE_DESCRIPTION</string>
         </config-file>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -66,6 +66,15 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <!-- ios -->
     <platform name="ios">
 
+        <!-- Location Usage Description -->
+        <preference name="USAGE_DESCRIPTION" default="The application needs to access location data to make the user experience more efficient and reliable." />
+        <config-file parent="NSLocationAlwaysAndWhenInUseUsageDescription" target="*-Info.plist">
+            <string>$USAGE_DESCRIPTION</string>
+        </config-file>
+        <config-file parent="NSLocationWhenInUseUsageDescription" target="*-Info.plist">
+            <string>$USAGE_DESCRIPTION</string>
+        </config-file>
+
         <js-module src="www/Coordinates.js" name="Coordinates">
             <clobbers target="Coordinates" />
         </js-module>

--- a/plugin.xml
+++ b/plugin.xml
@@ -67,11 +67,11 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <platform name="ios">
 
         <!-- Location Usage Description -->
-        <preference name="USAGE_DESCRIPTION" default="The application needs to access location data to make the user experience more efficient and reliable." />
+        <preference name="USAGE_DESCRIPTION" default="The application needs to access location data to make the user experience more efficient and reliable." mode="overwrite" />
         <config-file parent="NSLocationAlwaysAndWhenInUseUsageDescription" target="*-Info.plist">
             <string>$USAGE_DESCRIPTION</string>
         </config-file>
-        <config-file parent="NSLocationWhenInUseUsageDescription" target="*-Info.plist">
+        <config-file parent="NSLocationWhenInUseUsageDescription" target="*-Info.plist" mode="overwrite">
             <string>$USAGE_DESCRIPTION</string>
         </config-file>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -68,9 +68,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <!-- Location Usage Description -->
         <preference name="USAGE_DESCRIPTION" default="The application needs to access location data to make the user experience more efficient and reliable." />
-        <config-file parent="NSLocationAlwaysAndWhenInUseUsageDescription" target="*-Info.plist" mode="overwrite">
-            <string>$USAGE_DESCRIPTION</string>
-        </config-file>
         <config-file parent="NSLocationWhenInUseUsageDescription" target="*-Info.plist" mode="overwrite">
             <string>$USAGE_DESCRIPTION</string>
         </config-file>

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -29,7 +29,7 @@
     <dependency id="cordova-plugin-device" url="https://github.com/apache/cordova-plugin-device" />
     <js-module src="tests.js" name="tests">
     </js-module>
-    <edit-config target="NSLocationWhenInUseUsageDescription" file="*-Info.plist" mode="merge">
-      <string>need location access to pass tests</string>
-    </edit-config>
+    <config-file parent="NSLocationWhenInUseUsageDescription" target="*-Info.plist" mode="overwrite">
+        <string>need location access to pass tests</string>
+    </config-file>
 </plugin>

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -29,7 +29,7 @@
     <dependency id="cordova-plugin-device" url="https://github.com/apache/cordova-plugin-device" />
     <js-module src="tests.js" name="tests">
     </js-module>
-    <config-file parent="NSLocationWhenInUseUsageDescription" target="*-Info.plist" mode="overwrite">
+    <config-file parent="NSLocationWhenInUseUsageDescription" target="*-Info.plist">
         <string>need location access to pass tests</string>
     </config-file>
 </plugin>


### PR DESCRIPTION
## Platforms affected

iOS

## What does this PR do?

This PR makes the plugin works properly on iOS without extra changes in the config.xml and without conflicts with other plugins. The README.md is updated accordingly.

## What testing has been done on this change?

This PR replaces the tag edit-config by the tag config-file in the test context plugin.xml.

The cordova documentation imply [config-file](https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#config-file) is designed and tested for iOS plist.info when [edit-config](https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#edit-config) is designed for more complex xml syntax, like an android manifest.xml file. The merge mode available for edit-config is designed for merging up two tags with attributes (xml tags in a plist have no attributes).

According the documentation, using edit-config on a plist.info file is not a secure practice. Adding the mode attribute to "merge" makes it worst.

If a third plugin make wrong things in its plugin.xml, it may create issues and conflicts, but it won't be coming from this PR.

This PR is tested and reliable.