### PR TITLE
Add Apache Cordova issue tracker link to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ are not available until after the `deviceready` event.
     }
 
 ```
+
+⚠️ Report issues on the [Apache Cordova issue tracker](https://issues.apache.org/jira/browse/CB-12082?jql=project%20%3D%20CB%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20cordova-plugin-geolocation%20ORDER%20BY%20priority%20DESC%2C%20summary%20ASC%2C%20updatedDate%20DESC)
+
 ## <a id="reference"></a>Reference
 ## Installation
 


### PR DESCRIPTION
### What does this PR do?
Updated the Readme file to include a link to the Apache Cordova issue tracker
