### PR TITLE
ci(travis): add missing platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,14 @@ matrix:
     # local tests, without saucelabs
     - env: PLATFORM=local/browser
       <<: *_ios
+    - env: PLATFORM=local/ios-10.0
+      <<: *_ios
 
     # many tests with saucelabs
     - env: PLATFORM=browser-chrome
+    - env: PLATFORM=browser-firefox
+    - env: PLATFORM=browser-safari
+    - env: PLATFORM=browser-edge
 
     - env: PLATFORM=ios-11.3
       <<: *_ios

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,10 @@ _android: &_android
 
 matrix:
   include:    
+    # local tests, without saucelabs
+    - env: PLATFORM=local/browser
+      <<: *_ios
+
     # many tests with saucelabs
     - env: PLATFORM=browser-chrome
 


### PR DESCRIPTION
The Travis configuration is currently missing some platforms because there are issues:

https://github.com/apache/cordova-plugin-geolocation/issues/159
https://github.com/apache/cordova-plugin-geolocation/issues/158

When those are fixed, this can be merged to improve the coverage of the CI.