### PR TITLE
Added ANDROID_GPS_REQUIRED parameter for optional GPS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -34,6 +34,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <engines>
         <engine name="cordova-android" version=">=6.3.0" />
     </engines>
+    <preference name="ANDROID_GPS_REQUIRED" default="true"/>
 
     <!-- android -->
     <platform name="android">
@@ -41,7 +42,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
             <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-            <uses-feature android:name="android.hardware.location.gps" />
+            <uses-feature android:name="android.hardware.location.gps" android:required="$ANDROID_GPS_REQUIRED" />
         </config-file>
 
         <config-file target="res/xml/config.xml" parent="/*">


### PR DESCRIPTION
Added ANDROID_GPS_REQUIRED parameter with default value "true".
The input value will be set in the `android:required=` parameter for the uses-feature rule in the AndroidManifest.xml file.
Renders #86 and #98 obsolete

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
Supersedes PR #86 and #98 
Developer now can specify that the GPS is not mandatory, allowing the app to be distributed in the Store for devices without GPS.

### Description
Added ANDROID_GPS_REQUIRED parameter. Possible values are: `true` (default), `false`.

### Testing
Tested plugin installation and usage with cordova@7.1.0 and cordova-android@6.3.0
Added the plugin and tested it on different Android devices, even those without actual GPS. Android Location methods supplant the real GPS just fine and the location method still work properly, but without the accuracy of a real GPS of course.

### Checklist

- [X] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
