### PR TITLE
(ios) Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,18 +156,26 @@ error, the `geolocationError` callback is passed a
 
 ### iOS Quirks
  
- Since iOS 10 it's mandatory to provide an usage description in the `info.plist` if trying to access privacy-sensitive data. When the system prompts the user to allow access, this usage description string will displayed as part of the permission dialog box, but if you didn't provide the usage description, the app will crash before showing the dialog. Also, Apple will reject apps that access private data but don't provide an usage description.
+ Since iOS 10 it's mandatory to provide an usage description (NSLocationWhenInUseUsageDescription) in the `info.plist` if trying to access privacy-sensitive data. When the system prompts the user to allow access, this usage description string will displayed as part of the permission dialog box, but if you didn't provide the usage description, the app will crash before showing the dialog. Also, Apple will reject apps that access private data but don't provide an usage description.
 
- This plugins requires the following usage description:
+Starting Spring 2019, all apps submitted to the App Store that access user data also are required to include a purpose string (NSLocationAlwaysUsageDescription). If you're using external libraries or SDKs, they may reference APIs that require a purpose string. While your app might not use these APIs, a purpose string is still required. You can contact the developer of the library or SDK and request they release a version of their code that doesn't contain the APIs. [Learn more] (https://developer.apple.com/documentation/uikit/core_app/protecting_the_user_s_privacy)
+
+ This plugins requires the following usage descriptions:
 
  * `NSLocationWhenInUseUsageDescription` describes the reason that the app accesses the user's location. 
+ * `NSLocationAlwaysUsageDescription` user-facing purpose string explaining clearly and completely why your app needs the data.
 
- To add this entry into the `info.plist`, you can use the `edit-config` tag in the `config.xml` like this:
+ To add these entries into the `info.plist`, you can use the `edit-config` tag in the `config.xml` like this:
 
 ```
-<edit-config target="NSLocationWhenInUseUsageDescription" file="*-Info.plist" mode="merge">
-    <string>need location access to find things nearby</string>
-</edit-config>
+<platform name="ios">
+    <edit-config target="NSLocationWhenInUseUsageDescription" file="*-Info.plist" mode="merge">
+        <string>need location access to find things nearby</string>
+    </edit-config>
+    <edit-config target="NSLocationAlwaysUsageDescription" file="*-Info.plist" mode="merge">
+        <string>need location access to find things nearby</string>
+    </edit-config>
+</platform>
 ```
  
 ### Android Quirks


### PR DESCRIPTION
Apple complaints on missing `NSLocationAlwaysUsageDescription` key in "*-Info.plist" file.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
ios


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Apple won't approve the app otherwise
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->
Added info and example about how to add an additional key with string value to config.xml that is added to the app's Info.plist file upon build.


### Testing
<!-- Please describe in detail how you tested your changes. -->
When the key is not present in the config.xml, Apple sends an email with info about a missing key in the app's Info.plist file when you upload the archive file to Apple Store.
When including the key `NSLocationAlwaysUsageDescription `according to my description, Apple does not complain anymore.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
