### PR TITLE
Variable for Require GPS Hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ error, the `geolocationError` callback is passed a
  
 ### Android Quirks
 
+For historic reasons, this plugin requires GPS Hardware on Android devices, so your app will not be able to run on devices without.
+If you want to use this plugin in your app, but you do not require actual GPS Hardware on the device, install the plugin using the variable *GPS_REQUIRED*
+
+    cordova plugin add cordova-plugin-geolocation --variable GPS_REQUIRED="false"
+
 If Geolocation service is turned off the `onError` callback is invoked after `timeout` interval (if specified).
 If `timeout` parameter is not specified then no callback is called.
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ error, the `geolocationError` callback is passed a
 ### Android Quirks
 
 For historic reasons, this plugin requires GPS Hardware on Android devices, so your app will not be able to run on devices without.
-If you want to use this plugin in your app, but you do not require actual GPS Hardware on the device, install the plugin using the variable *GPS_REQUIRED*
+If you want to use this plugin in your app, but you do not require actual GPS Hardware on the device, install the plugin using the variable *GPS_REQUIRED* set to false:
 
     cordova plugin add cordova-plugin-geolocation --variable GPS_REQUIRED="false"
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -34,6 +34,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <engines>
         <engine name="cordova-android" version=">=6.3.0" />
     </engines>
+    <preference name="GPS_REQUIRED" default="true"/>
 
     <!-- android -->
     <platform name="android">
@@ -41,7 +42,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
             <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-            <uses-feature android:name="android.hardware.location.gps" />
+            <uses-feature android:name="android.hardware.location.gps" android:required="$GPS_REQUIRED" />
         </config-file>
 
         <config-file target="res/xml/config.xml" parent="/*">


### PR DESCRIPTION

### Platforms affected
Android


### Motivation and Context
Currently installing this plugin, has the sideeffect of your App only beeing installable on Android devices with GPS hardware. We have clients with tablets without GPS hardware.

closes #187 
closes #171
closes #86
closes #98

### Description
Added the variable **GPS_REQUIRED** so when installing the pluging, its optional if you want to require GPS Hardware on Android devices. Currently an app with this plugin, cannot run on devices without GPS Hardware, because of this setting in the plugin.xml

`<uses-feature android:name="android.hardware.location.gps" />`

Also added a description in the readme, under Android Quirks, as this only affects Android atm.

Naming of the variable is all caps, as is standard with install time variables, for editing the AndroidManifest.xml.

This PR is trying to finish the work in #171 

### Testing
Testing installing the plugin with and without the variable, and checked the resulting androidmanifest.xml and tested the resulting apk's.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
