### PR TITLE
docs: Removed misleading text

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ device's actual location.
 > To get a few ideas, check out the [sample](#sample) at the bottom of this page or go straight to the [reference](#reference) content.
 
 This API is based on the
-[W3C Geolocation API Specification](http://dev.w3.org/geo/api/spec-source.html),
-and only executes on devices that don't already provide an implementation.
+[W3C Geolocation API Specification](http://dev.w3.org/geo/api/spec-source.html).
 
 __WARNING__: Collection and use of geolocation data
 raises important privacy issues.  Your app's privacy policy should


### PR DESCRIPTION
"This API is based on the W3C Geolocation API Specification, and only executes on devices that don't already provide an implementation."

is misleading because it sounds like you do not need the plugin if the browser has geolocation support,
however, the plugin still handles permissions regardless if it provides
a geolocation implementation or not.

Closes #186 

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
