### PR TITLE
(ios) Continue watchPosition when the App is suspended and reactivated, fixes #224

### DIFF
--- a/src/ios/CDVLocation.m
+++ b/src/ios/CDVLocation.m
@@ -80,9 +80,8 @@
     return YES;
 }
 
-- (BOOL)isLocationServicesEnabled
+- (BOOL)isLocationServicesEnabled // returns true if GLOBAL system-wide location services are enabled (Settings > Privacy)
 {
-    BOOL locationServicesEnabledInstancePropertyAvailable = [self.locationManager respondsToSelector:@selector(locationServicesEnabled)]; // iOS 3.x
     BOOL locationServicesEnabledClassPropertyAvailable = [CLLocationManager respondsToSelector:@selector(locationServicesEnabled)]; // iOS 4.x
     
     if (locationServicesEnabledClassPropertyAvailable) { // iOS 4.x
@@ -213,7 +212,7 @@
                 }
             }
             
-            if (!__locationStarted || (__highAccuracyEnabled != enableHighAccuracy)) {
+            if (!self->__locationStarted || (self->__highAccuracyEnabled != enableHighAccuracy)) {
                 // add the callbackId into the array so we can call back when get data
                 @synchronized (self.locationData.locationCallbacks) {
                     if (callbackId != nil) {
@@ -331,7 +330,7 @@
 
 - (void)locationManager:(CLLocationManager*)manager didFailWithError:(NSError*)error
 {
-    NSLog(@"locationManager::didFailWithError %@", [error localizedFailureReason]);
+    NSLog(@"CDVLocation locationManager:didFailWithError: %ld %@ isLocationServicesEnabled:%i isAuthorized:%i", (long)error.code, [error localizedDescription], [self isLocationServicesEnabled], [self isAuthorized]);
     
     CDVLocationData* lData = self.locationData;
     if (lData && __locationStarted) {

--- a/src/ios/CDVLocation.m
+++ b/src/ios/CDVLocation.m
@@ -344,11 +344,16 @@
         }
         [self returnLocationError:positionError withMessage:[error localizedDescription]];
     }
+        
+    if (error.code == kCLErrorLocationUnknown || error.code == kCLErrorHeadingFailure) // recoverable
+        return;
     
-    if (error.code != kCLErrorLocationUnknown) {
-        [self.locationManager stopUpdatingLocation];
-        __locationStarted = NO;
-    }
+    if(error.code == kCLErrorDenied && [self isAuthorized] && [self isLocationServicesEnabled]) // suspended app, recoverable
+        return;
+    
+    // cancel the location service due to permanent failure or user permission
+    [self.locationManager stopUpdatingLocation];
+    __locationStarted = NO;
 }
 
 //iOS8+


### PR DESCRIPTION
### Platforms affected
iOS

### Motivation and Context
Fixes issue https://github.com/apache/cordova-plugin-geolocation/issues/224

### Description
```
if(error.code == kCLErrorDenied && [self isAuthorized] && [self isLocationServicesEnabled])
   then do not stopUpdatingLocation and thus continue watchPosition after suspending the app and reactivating it
```
### Testing
Manual tests on iPhone

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
