### PR TITLE
ci: Sync with paramedic. Removed API 22 & 31, added API 24 & API 33

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -57,8 +57,8 @@ jobs:
       matrix:
         versions:
           # Test the lowest minimum supported APIs
-          - android: 5.1
-            android-api: 22
+          - android: 7
+            android-api: 24
 
           # Test the last 3-4 supported APIs
           - android: 10
@@ -67,11 +67,11 @@ jobs:
           - android: 11
             android-api: 30
 
-          - android: 12
-            android-api: 31
-
           - android: 12L
             android-api: 32
+
+          - android: 13
+            android-api: 33
 
     timeout-minutes: 60
 
@@ -105,7 +105,7 @@ jobs:
         if: ${{ endswith(env.repo, '/cordova-paramedic') != true }}
         run: npm i -g github:apache/cordova-paramedic
 
-      - uses: reactivecircus/android-emulator-runner@5de26e4bd23bf523e8a4b7f077df8bfb8e52b50e
+      - uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b
         env:
           system-image-arch: ${{ matrix.versions.system-image-arch == '' && env.default_system-image-arch || matrix.versions.system-image-arch }}
           system-image-target: ${{ matrix.versions.system-image-target == '' && env.default_system-image-target || matrix.versions.system-image-target }}
@@ -119,7 +119,7 @@ jobs:
           script: echo "Pregenerate the AVD before running Paramedic"
 
       - name: Run paramedic tests
-        uses: reactivecircus/android-emulator-runner@5de26e4bd23bf523e8a4b7f077df8bfb8e52b50e
+        uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b
         env:
           system-image-arch: ${{ matrix.versions.system-image-arch == '' && env.default_system-image-arch || matrix.versions.system-image-arch }}
           system-image-target: ${{ matrix.versions.system-image-target == '' && env.default_system-image-target || matrix.versions.system-image-target }}


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

CI

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Updated CI for modern tests

### Description
<!-- Describe your changes in detail -->
Updated for API 33 coverage.
Removed API 22 as it is no longer supported.
Removed API 31 as it's effectively the same as API 32, which is just a feature update on top of API 31.
Reactivecircus was updated to match the paramedic config.


### Testing
<!-- Please describe in detail how you tested your changes. -->

Letting CI do it's thing.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
