### PR TITLE
chore: bump to 5.0.0-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-plugin-geolocation",
-  "version": "4.1.1-dev",
+  "version": "5.0.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-plugin-geolocation",
-      "version": "4.1.1-dev",
+      "version": "5.0.0-dev",
       "license": "Apache-2.0",
       "devDependencies": {
         "@cordova/eslint-config": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-geolocation",
-  "version": "4.1.1-dev",
+  "version": "5.0.0-dev",
   "description": "Cordova Geolocation Plugin",
   "cordova": {
     "id": "cordova-plugin-geolocation",
@@ -31,7 +31,7 @@
       "3.0.0": {
         "cordova-android": ">=6.3.0"
       },
-      "5.0.0": {
+      "6.0.0": {
         "cordova": ">100"
       }
     }

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
 xmlns:rim="http://www.blackberry.com/ns/widgets"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-geolocation"
-      version="4.1.1-dev">
+      version="5.0.0-dev">
 
     <name>Geolocation</name>
     <description>Cordova Geolocation Plugin</description>

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-geolocation-tests",
-  "version": "4.1.1-dev",
+  "version": "5.0.0-dev",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-geolocation-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-geolocation-tests"
-    version="4.1.1-dev">
+    version="5.0.0-dev">
     <name>Cordova Geolocation Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
Despite not being marked https://github.com/apache/cordova-plugin-geolocation/commit/68fe464f5414b3621005b6a22158f761cd21adfd is a breaking change since it's moving from es3 to es5/es6 features. (e.g. `var` -> `let` / `const`)