### PR TITLE
fix: heading speed w3c spec

### DIFF
--- a/www/Coordinates.js
+++ b/www/Coordinates.js
@@ -50,7 +50,7 @@ const Coordinates = function (lat, lng, alt, acc, head, vel, altacc) {
     /**
      * The direction the device is moving at the position.
      */
-    this.heading = head !== undefined ? head : null;
+    this.heading = (typeof head === 'number' && head >= 0 && head <= 360 ? head : null);
     /**
      * The velocity with which the device is moving at the position.
      */

--- a/www/Coordinates.js
+++ b/www/Coordinates.js
@@ -54,7 +54,7 @@ const Coordinates = function (lat, lng, alt, acc, head, vel, altacc) {
     /**
      * The velocity with which the device is moving at the position.
      */
-    this.speed = vel !== undefined ? vel : null;
+    this.speed = (typeof vel === 'number' && vel >= 0 ? vel : null);
 
     if (this.speed === 0 || this.speed === null) {
         this.heading = NaN;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

ALl

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Rebase of https://github.com/apache/cordova-plugin-geolocation/pull/77

Maintains the W3C spec by initializing `speed` and `heading` to `null` if the values are not found or not within the expected range. See https://w3c.github.io/geolocation-api/#constructing-a-geolocationposition for more details:

> Initialize coord's [speed](https://w3c.github.io/geolocation-api/#dom-geolocationcoordinates-speed) attribute to a non-negative real number, or as null if the implementation cannot provide speed information.

> Initialize coord's [heading](https://w3c.github.io/geolocation-api/#dom-geolocationcoordinates-heading) attribute in degrees, or null if the implementation cannot provide heading information.

### Description
<!-- Describe your changes in detail -->

Asserts the values are in proper range

### Testing
<!-- Please describe in detail how you tested your changes. -->

- Ran paramedic tests on iOS 16.4
- Ran paramedic tests on Android
- Ran `npm test`

Note that test fails without manual interactions on the simulator due to the permission prompts.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
