### PR TITLE
fix!: Bump engine requirements android >= 10, ios >= 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ It is also possible to install via repo url directly ( unstable )
 
 ## Supported Platforms
 
-- Android
-- iOS
+- Android (10.0.0 or later)
+- iOS (6.0.0 or later)
 
 ## Methods
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,10 @@
           "3.0.0": {
             "cordova-android": ">=6.3.0"
           },
+          "5.0.0": {
+            "cordova-android": ">=10.0.0",
+            "cordova-ios": ">=6.0.0"
+          },
           "6.0.0": {
             "cordova": ">100"
           }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
       "3.0.0": {
         "cordova-android": ">=6.3.0"
       },
+      "5.0.0": {
+        "cordova-android": ">=10.0.0",
+        "cordova-ios": ">=6.0.0"
+      },
       "6.0.0": {
         "cordova": ">100"
       }

--- a/plugin.xml
+++ b/plugin.xml
@@ -32,7 +32,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <issue>https://github.com/apache/cordova-plugin-geolocation/issues</issue>
 
     <engines>
-        <engine name="cordova-android" version=">=6.3.0" />
+        <engine name="cordova-android" version=">=10.0.0" />
+        <engine name="cordova-ios" version=">=6.0.0" />
     </engines>
     <preference name="GPS_REQUIRED" default="true"/>
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android / iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

There were concerns raised during 5.0.0 release: https://lists.apache.org/thread/dzmm273b76pngtor6386s71yzf6lzxck

> I’ve read the blog post and it mentions “The JavaScript of the plugin has
been upgraded to use ES6 features, such as `let` and `const`.”.
But the plugin engines still support cordova-android 6+.
Should we bump the engines to require latest cordova-android? Those new ES6
features won’t work on those old cordova-android versions.

To address these concerns, this caveat is noted in the release blog (see https://github.com/apache/cordova-docs/pull/1335). While this is technically a breaking change it can be thought of a patch onto 5.0.1 and be included in our next patch or feature release.

### Description
<!-- Describe your changes in detail -->

Bump engine versions in both plugin.xml and package.json
cordova-android >= 10 for min SDK 22 (cordova-android 9 also had minSDK 22 but dependent on jfrog)
cordova-ios >= 6 for iOS 11 minimum deployment

iOS 11 has good support for ES6 (however with some buggy behaviour)
SDK 22 ships with Chrome 33 which has, but `let` was only introduced Chrome 49 (41 with strict mode). So it's possible that SDK 22 won't be sufficient, depending on the end-users webview version but this is upgradeable and the latest version available for these devices is Chrome ~70.

Cordova-android@12 has a min SDK of 24 which AOSP simulators ships with Chrome 53. In all likeliness this is what most people will see.

Additionally I updated the README to mention these new requirements.

### Testing
<!-- Please describe in detail how you tested your changes. -->

ran npm test

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
