### PR TITLE
Feature/location service

### DIFF
--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -91,11 +91,11 @@ public class Geolocation extends CordovaPlugin {
 
     public boolean hasPermission(String[] permissions) {
         for (String p : permissions) {
-            if (PermissionHelper.hasPermission(this, p)) {
-                return true;
+            if (!PermissionHelper.hasPermission(this, p)) {
+                return false;
             }
         }
-        return false;
+        return true;
     }
 
     /*

--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -14,8 +14,6 @@
        specific language governing permissions and limitations
        under the License.
  */
-
-
 package org.apache.cordova.geolocation;
 
 import android.content.Context;
@@ -32,16 +30,14 @@ import org.apache.cordova.LOG;
 import org.json.JSONArray;
 import org.json.JSONException;
 
-
 public class Geolocation extends CordovaPlugin {
 
     String TAG = "GeolocationPlugin";
     CallbackContext context;
 
-
-    String [] highAccuracyPermissions = { Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION };
-    String [] lowAccuracyPermissions = { Manifest.permission.ACCESS_COARSE_LOCATION };
-    String [] permissionsToRequest;
+    String[] highAccuracyPermissions = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION};
+    String[] lowAccuracyPermissions = {Manifest.permission.ACCESS_COARSE_LOCATION};
+    String[] permissionsToRequest;
     String[] permissionsToCheck;
 
     LocationManager manager;
@@ -49,10 +45,8 @@ public class Geolocation extends CordovaPlugin {
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         LOG.d(TAG, "We are entering execute");
         context = callbackContext;
-        if(action.equals("getPermission"))
-        {
-            if(!isLocationProviderAvailable())
-            {
+        if (action.equals("getPermission")) {
+            if (!isLocationProviderAvailable()) {
                 LOG.d(TAG, "Location Provider Unavailable!");
                 PluginResult result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION);
                 context.sendPluginResult(result);
@@ -66,13 +60,11 @@ public class Geolocation extends CordovaPlugin {
             // See https://bugs.chromium.org/p/chromium/issues/detail?id=1269362
             permissionsToRequest = Build.VERSION.SDK_INT <= 31 ? highAccuracyPermissions : permissionsToCheck;
 
-            if(hasPermission(permissionsToCheck))
-            {
+            if (hasPermission(permissionsToCheck)) {
                 PluginResult r = new PluginResult(PluginResult.Status.OK, Build.VERSION.SDK_INT);
                 context.sendPluginResult(r);
                 return true;
-            }
-            else {
+            } else {
                 PermissionHelper.requestPermissions(this, 0, permissionsToRequest);
             }
             return true;
@@ -80,22 +72,16 @@ public class Geolocation extends CordovaPlugin {
         return false;
     }
 
-
-    public void onRequestPermissionResult(int requestCode, String[] permissions,
-                                          int[] grantResults) throws JSONException
-    {
+    public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) {
         PluginResult result;
         //This is important if we're using Cordova without using Cordova, but we have the geolocation plugin installed
-        if(context != null) {
-            for (int i=0; i<grantResults.length; i++) {
-                int r = grantResults[i];
-                String p = permissions[i];
+        if (context != null) {
+            for (int r : grantResults) {
                 if (r == PackageManager.PERMISSION_GRANTED) {
                     result = new PluginResult(PluginResult.Status.OK);
                     context.sendPluginResult(result);
                     return;
                 }
-
             }
             LOG.d(TAG, "Permission Denied!");
             result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION);
@@ -104,10 +90,8 @@ public class Geolocation extends CordovaPlugin {
     }
 
     public boolean hasPermission(String[] permissions) {
-        for(String p : permissions)
-        {
-            if(PermissionHelper.hasPermission(this, p))
-            {
+        for (String p : permissions) {
+            if (PermissionHelper.hasPermission(this, p)) {
                 return true;
             }
         }
@@ -118,15 +102,12 @@ public class Geolocation extends CordovaPlugin {
      * We override this so that we can access the permissions variable, which no longer exists in
      * the parent class, since we can't initialize it reliably in the constructor!
      */
-
-    public void requestPermissions(int requestCode)
-    {
+    public void requestPermissions(int requestCode) {
         PermissionHelper.requestPermissions(this, requestCode, permissionsToRequest);
     }
 
-    private boolean isLocationProviderAvailable()
-    {
+    private boolean isLocationProviderAvailable() {
         manager = (LocationManager) this.cordova.getActivity().getApplicationContext().getSystemService(Context.LOCATION_SERVICE);
-        return manager.isProviderEnabled(LocationManager.FUSED_PROVIDER);
+        return manager.isProviderEnabled(LocationManager.GPS_PROVIDER) || manager.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
     }
 }

--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -55,7 +55,7 @@ public class Geolocation extends CordovaPlugin {
             // See https://bugs.chromium.org/p/chromium/issues/detail?id=1269362
             permissionsToRequest = Build.VERSION.SDK_INT <= 31 ? highAccuracyPermissions : permissionsToCheck;
 
-            if(hasPermisssion(permissionsToCheck))
+            if(hasPermission(permissionsToCheck))
             {
                 PluginResult r = new PluginResult(PluginResult.Status.OK, Build.VERSION.SDK_INT);
                 context.sendPluginResult(r);
@@ -92,7 +92,7 @@ public class Geolocation extends CordovaPlugin {
         }
     }
 
-    public boolean hasPermisssion(String[] permissions) {
+    public boolean hasPermission(String[] permissions) {
         for(String p : permissions)
         {
             if(PermissionHelper.hasPermission(this, p))

--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -79,15 +79,15 @@ public class Geolocation extends CordovaPlugin {
             for (int i=0; i<grantResults.length; i++) {
                 int r = grantResults[i];
                 String p = permissions[i];
-                if (r == PackageManager.PERMISSION_DENIED && arrayContains(permissionsToCheck, p)) {
-                    LOG.d(TAG, "Permission Denied!");
-                    result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION);
+                if (r == PackageManager.PERMISSION_GRANTED) {
+                    result = new PluginResult(PluginResult.Status.OK);
                     context.sendPluginResult(result);
                     return;
                 }
 
             }
-            result = new PluginResult(PluginResult.Status.OK);
+            LOG.d(TAG, "Permission Denied!");
+            result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION);
             context.sendPluginResult(result);
         }
     }
@@ -95,12 +95,12 @@ public class Geolocation extends CordovaPlugin {
     public boolean hasPermisssion(String[] permissions) {
         for(String p : permissions)
         {
-            if(!PermissionHelper.hasPermission(this, p))
+            if(PermissionHelper.hasPermission(this, p))
             {
-                return false;
+                return true;
             }
         }
-        return true;
+        return false;
     }
 
     /*
@@ -111,22 +111,6 @@ public class Geolocation extends CordovaPlugin {
     public void requestPermissions(int requestCode)
     {
         PermissionHelper.requestPermissions(this, requestCode, permissionsToRequest);
-    }
-
-    //https://stackoverflow.com/a/12635769/777265
-    private <T> boolean arrayContains(final T[] array, final T v) {
-        if (v == null) {
-            for (final T e : array)
-                if (e == null)
-                    return true;
-        }
-        else {
-            for (final T e : array)
-                if (e == v || v.equals(e))
-                    return true;
-        }
-
-        return false;
     }
 
 }

--- a/src/android/Geolocation.java
+++ b/src/android/Geolocation.java
@@ -18,8 +18,10 @@
 
 package org.apache.cordova.geolocation;
 
+import android.content.Context;
 import android.content.pm.PackageManager;
 import android.Manifest;
+import android.location.LocationManager;
 import android.os.Build;
 
 import org.apache.cordova.CallbackContext;
@@ -42,12 +44,21 @@ public class Geolocation extends CordovaPlugin {
     String [] permissionsToRequest;
     String[] permissionsToCheck;
 
+    LocationManager manager;
 
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         LOG.d(TAG, "We are entering execute");
         context = callbackContext;
         if(action.equals("getPermission"))
         {
+            if(!isLocationProviderAvailable())
+            {
+                LOG.d(TAG, "Location Provider Unavailable!");
+                PluginResult result = new PluginResult(PluginResult.Status.ILLEGAL_ACCESS_EXCEPTION);
+                context.sendPluginResult(result);
+                return true;
+            }
+
             boolean highAccuracy = args.getBoolean(0);
             permissionsToCheck = highAccuracy ? highAccuracyPermissions : lowAccuracyPermissions;
 
@@ -113,4 +124,9 @@ public class Geolocation extends CordovaPlugin {
         PermissionHelper.requestPermissions(this, requestCode, permissionsToRequest);
     }
 
+    private boolean isLocationProviderAvailable()
+    {
+        manager = (LocationManager) this.cordova.getActivity().getApplicationContext().getSystemService(Context.LOCATION_SERVICE);
+        return manager.isProviderEnabled(LocationManager.FUSED_PROVIDER);
+    }
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- This is change for check Location Service enabled before request permission.\ For now when the location service is unavailable, the plugin request permission, open dialog and wait for timeout. Referencing `Note: Browser permission VS OS permission` in [W3C](https://w3c.github.io/geolocation/#introduction), I interpreted location service availability is similar to OS permission and it should return [PERMISSION_DENIED](https://w3c.github.io/geolocation/#dom-geolocationpositionerror-permission_denied).
- In [W3C](https://w3c.github.io/geolocation/#introduction), it looks no distinction between fine and coarse location permissions. And WebView return coarse location ignoring `enableHighAccuracy` when denied permission for fine location.


### Description
<!-- Describe your changes in detail -->
- When request high accuracy location but only granted coarse location, onRequestPermissionResult() return `PluginResult.Status.OK`
- check location service before permission.

### Testing
<!-- Please describe in detail how you tested your changes. -->
I checked with virtual device location service on/off.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
