### PR TITLE
(browser) Added browser platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ It is also possible to install via repo url directly ( unstable )
 
 - Android (10.0.0 or later)
 - iOS (6.0.0 or later)
+- Browser (6.0.0 or later)
 
 ## Methods
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -94,4 +94,20 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <framework src="CoreLocation.framework" />
 
     </platform>
+
+	<!-- browser -->
+    <platform name="browser">
+
+        <config-file target="config.xml" parent="/*">
+            <feature name="Geolocation">
+                <param name="browser-package" value="Geolocation"/>
+            </feature>
+        </config-file>
+
+        <js-module src="src/browser/GeolocationProxy.js" name="GeolocationProxy">
+            <runs/>
+        </js-module>
+
+    </platform>
+
 </plugin>

--- a/src/browser/GeolocationProxy.js
+++ b/src/browser/GeolocationProxy.js
@@ -1,0 +1,79 @@
+// GeolocationProxy.js
+var geolocation = {
+    getCurrentPosition: function(successCallback, errorCallback, options) {
+        if (!navigator.geolocation) {
+            errorCallback({
+                code: 2,
+                message: "Geolocation not supported"
+            });
+            return;
+        }
+
+        navigator.geolocation.getCurrentPosition(
+            function(position) {
+                successCallback({
+                    coords: {
+                        latitude: position.coords.latitude,
+                        longitude: position.coords.longitude,
+                        altitude: position.coords.altitude,
+                        accuracy: position.coords.accuracy,
+                        altitudeAccuracy: position.coords.altitudeAccuracy,
+                        heading: position.coords.heading,
+                        speed: position.coords.speed
+                    },
+                    timestamp: position.timestamp
+                });
+            },
+            function(error) {
+                errorCallback({
+                    code: error.code,
+                    message: error.message
+                });
+            },
+            options
+        );
+    },
+
+    watchPosition: function(successCallback, errorCallback, options) {
+        if (!navigator.geolocation) {
+            errorCallback({
+                code: 2,
+                message: "Geolocation not supported"
+            });
+            return -1;
+        }
+
+        return navigator.geolocation.watchPosition(
+            function(position) {
+                successCallback({
+                    coords: {
+                        latitude: position.coords.latitude,
+                        longitude: position.coords.longitude,
+                        altitude: position.coords.altitude,
+                        accuracy: position.coords.accuracy,
+                        altitudeAccuracy: position.coords.altitudeAccuracy,
+                        heading: position.coords.heading,
+                        speed: position.coords.speed
+                    },
+                    timestamp: position.timestamp
+                });
+            },
+            function(error) {
+                errorCallback({
+                    code: error.code,
+                    message: error.message
+                });
+            },
+            options
+        );
+    },
+
+    clearWatch: function(watchId) {
+        if (navigator.geolocation) {
+            navigator.geolocation.clearWatch(watchId);
+        }
+    }
+};
+
+// Registrar el proxy en Cordova
+require('cordova/exec/proxy').add('Geolocation', geolocation);


### PR DESCRIPTION
### Platforms affected
- Browser (added by PR)

### Motivation and Context
- Plugin throwed error on browser platform, now it works normally.

### Description
- Added browser platform in plugin.xml and its proxy JS file.

### Testing
- Tested on Browser 6.0.0 and Firefox

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary